### PR TITLE
Replace parameter type

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,10 +47,11 @@ KituraRequest.request(.POST,
 ```
 
 Currently `URLEncoding`, `JSONEncoding` and `MultipartEncoding` encodings is supported by default.
-`URLEncoding` encodes parameters as URLs query.
-`JSONEncoding` converts parameters dictionary to JSON and appends it to request's body.
-`MultipartEncoding` generates multipart http body from passed parameters and appends it to request's body.
-When encoding parameters as `JSONEncoding` or `MultipartEncoding` appropriate Content-Type header is set.
+
+`URLEncoding` encodes parameters as URLs query.  
+`JSONEncoding` converts parameters dictionary to JSON and appends it to request's body.  
+`MultipartEncoding` generates multipart http body from passed parameters and appends it to request's body.  
+When encoding parameters as `JSONEncoding` or `MultipartEncoding` appropriate Content-Type header is set.  
 To create custom parameter encoding extend any class or struct with `Encoding` protocol.
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -37,16 +37,21 @@ KituraRequest.request(.GET, "https://httpbin.org/get"]
 ```
 
 #### Request parameters and parameters encoding
-You can also create a request with parameters by passing `[[String: Any]]` array of dictionaries together with an encoding method:
+You can also create a request with parameters by passing `[String: Any]` dictionary together with an encoding method:
 
 ```swift
 KituraRequest.request(.POST,
                       "https://httpbin.org/post",
-                      parameters: [["foo":"bar"]],
-                      encoding: .JSON)
+                      parameters: ["foo":"bar"],
+                      encoding: JSONEncoding.default)
 ```
 
-Currently `.URL` and `.JSON` encoding is supported. `.URL` encodes parameters as URLs query while the latter converts parameters dictionary to JSON and appends it to request's body. When encoding parameters as `.JSON` appropriate Content-Type header is set.
+Currently `URLEncoding`, `JSONEncoding` and `MultipartEncoding` encodings is supported by default.
+`URLEncoding` encodes parameters as URLs query.
+`JSONEncoding` converts parameters dictionary to JSON and appends it to request's body.
+`MultipartEncoding` generates multipart http body from passed parameters and appends it to request's body.
+When encoding parameters as `JSONEncoding` or `MultipartEncoding` appropriate Content-Type header is set.
+To create custom parameter encoding extend any class or struct with `Encoding` protocol.
 
 
 #### Headers

--- a/Sources/KituraRequest/Encoding/Encoding.swift
+++ b/Sources/KituraRequest/Encoding/Encoding.swift
@@ -53,14 +53,10 @@ extension Encoding {
     }
 
     static func getComponents(from parameters: Request.Parameters) -> Components {
-        var components = Components()
-
-        for dictionary in parameters {
-            components = dictionary.reduce(components) { value, element in
-                let key = element.0
-                let components = self.getComponents(key, element.1)
-                return value + components
-            }
+        let components = parameters.reduce(Components()) { value, element in
+            let key = element.0
+            let components = self.getComponents(key, element.1)
+            return value + components
         }
 
         return components

--- a/Sources/KituraRequest/Encoding/JSONEncoding.swift
+++ b/Sources/KituraRequest/Encoding/JSONEncoding.swift
@@ -27,9 +27,7 @@ public struct JSONEncoding: Encoding {
         guard let parameters = parameters, !parameters.isEmpty else { return }
 
         let options = JSONSerialization.WritingOptions()
-        let data = parameters.count == 1 ?
-            try JSONSerialization.data(withJSONObject: parameters[0], options: options) :
-            try JSONSerialization.data(withJSONObject: parameters, options: options)
+        let data = try JSONSerialization.data(withJSONObject: parameters, options: options)
         request.httpBody = data
     }
 }

--- a/Sources/KituraRequest/Request.swift
+++ b/Sources/KituraRequest/Request.swift
@@ -28,7 +28,7 @@ public class Request {
     var data: NSData?
     var error: Swift.Error?
 
-    public typealias Parameters = [[String : Any]]
+    public typealias Parameters = [String : Any]
 
     public enum Method: String {
         case CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE

--- a/Tests/KituraRequestTests/ParameterEncodingTests.swift
+++ b/Tests/KituraRequestTests/ParameterEncodingTests.swift
@@ -37,7 +37,7 @@ class ParameterEncodingTests: XCTestCase {
   func testJSONParameterEncodingWhenEmptyPassed() {
     var urlRequest = NSMutableURLRequest(url: url)
     do {
-        try JSONEncoding.default.encode(&urlRequest, parameters: [])
+        try JSONEncoding.default.encode(&urlRequest, parameters: [:])
         XCTAssertNil(urlRequest.httpBody)
     } catch {
       XCTFail()
@@ -47,7 +47,7 @@ class ParameterEncodingTests: XCTestCase {
   func testJSONParameterEncodingSetsHeaders() {
     var urlRequest = NSMutableURLRequest(url: url)
     do {
-        try JSONEncoding.default.encode(&urlRequest, parameters: [["p1":1]])
+        try JSONEncoding.default.encode(&urlRequest, parameters: ["p1":1])
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
     } catch {
       XCTFail()
@@ -57,7 +57,7 @@ class ParameterEncodingTests: XCTestCase {
   func testJSONParametersEncodingSetsBody() {
     var urlRequest = NSMutableURLRequest(url: url)
     do {
-        try JSONEncoding.default.encode(&urlRequest, parameters: [["p1":1]])
+        try JSONEncoding.default.encode(&urlRequest, parameters: ["p1":1])
         let body = dataToString(urlRequest.httpBody)
         XCTAssertEqual(body, "{\"p1\":1}")
     } catch {
@@ -67,7 +67,7 @@ class ParameterEncodingTests: XCTestCase {
     func testJSONParametersEncodingSetsBodyWithArray() {
         var urlRequest = NSMutableURLRequest(url: url)
         do {
-            try JSONEncoding.default.encode(&urlRequest, parameters: [["p1":[1,2]]])
+            try JSONEncoding.default.encode(&urlRequest, parameters: ["p1":[1,2]])
             let body = dataToString(urlRequest.httpBody)
             XCTAssertEqual(body, "{\"p1\":[1,2]}")
         } catch {
@@ -78,9 +78,13 @@ class ParameterEncodingTests: XCTestCase {
     func testJSONArrayParametersEncodingSetsBody() {
         var urlRequest = NSMutableURLRequest(url: url)
         do {
-            try JSONEncoding.default.encode(&urlRequest, parameters: [["p1":1], ["p2": 2]])
-            let body = dataToString(urlRequest.httpBody)
-            XCTAssertEqual(body, "[{\"p1\":1},{\"p2\":2}]")
+            try JSONEncoding.default.encode(&urlRequest, parameters: ["p1":1, "p2": 2])
+            guard let body = dataToString(urlRequest.httpBody) else {
+                XCTFail("should have a body")
+                return
+            }
+            XCTAssertTrue(body.contains("\"p1\":1"), "json encoding error")
+            XCTAssertTrue(body.contains("\"p2\":2"), "json encoding error")
         } catch {
             XCTFail()
         }
@@ -101,7 +105,7 @@ class ParameterEncodingTests: XCTestCase {
   func testURLParametersEncodingWithEmptyParameters() {
     var urlRequest = NSMutableURLRequest(url: url)
     do {
-        try URLEncoding.default.encode(&urlRequest, parameters: [])
+        try URLEncoding.default.encode(&urlRequest, parameters: [:])
         XCTAssertEqual(urlRequest.url?.absoluteString, url.absoluteString)
     } catch {
       XCTFail()
@@ -111,8 +115,13 @@ class ParameterEncodingTests: XCTestCase {
   func testURLParametersEncodingWithSimpleParameters() {
     var urlRequest = NSMutableURLRequest(url: url)
     do {
-        try URLEncoding.default.encode(&urlRequest, parameters: [["a":1], ["b":2]])
-        XCTAssertEqual(urlRequest.url?.query, "a=1&b=2") // this may be brittle
+        try URLEncoding.default.encode(&urlRequest, parameters: ["a":1, "b":2])
+        guard let query = urlRequest.url?.query else {
+            XCTFail("should have a body")
+            return
+        }
+        XCTAssertTrue(query.contains("a=1"), "url encoding error")
+        XCTAssertTrue(query.contains("b=2"), "url encoding error")
     } catch {
       XCTFail()
     }
@@ -121,7 +130,7 @@ class ParameterEncodingTests: XCTestCase {
   func testURLParametersEncodingWithArray() {
     var urlRequest = NSMutableURLRequest(url: url)
     do {
-        try URLEncoding.default.encode(&urlRequest, parameters: [["a":[1, 2]]])
+        try URLEncoding.default.encode(&urlRequest, parameters: ["a":[1, 2]])
         XCTAssertEqual(urlRequest.url?.query, "a%5B%5D=1&a%5B%5D=2") // this may be brittle
     } catch {
       XCTFail()
@@ -131,7 +140,7 @@ class ParameterEncodingTests: XCTestCase {
   func testURLParametersEncodingWithDictionary() {
     var urlRequest = NSMutableURLRequest(url: url)
     do {
-        try URLEncoding.default.encode(&urlRequest, parameters: [["a" : ["b" : 1]]])
+        try URLEncoding.default.encode(&urlRequest, parameters: ["a" : ["b" : 1]])
         XCTAssertEqual(urlRequest.url?.query, "a%5Bb%5D=1") // this may be brittle
     } catch {
       XCTFail()
@@ -141,7 +150,7 @@ class ParameterEncodingTests: XCTestCase {
   func testURLParametersEncodingWithArrayNestedInDict() {
     var urlRequest = NSMutableURLRequest(url: url)
     do {
-        try URLEncoding.default.encode(&urlRequest, parameters: [["a" : ["b" : [1, 2]]]])
+        try URLEncoding.default.encode(&urlRequest, parameters: ["a" : ["b" : [1, 2]]])
         XCTAssertEqual(urlRequest.url?.query, "a%5Bb%5D%5B%5D=1&a%5Bb%5D%5B%5D=2") // this may be brittle
     } catch {
       XCTFail()

--- a/Tests/KituraRequestTests/RequestTests.swift
+++ b/Tests/KituraRequestTests/RequestTests.swift
@@ -24,7 +24,7 @@ class RequestTests: XCTestCase {
 
   var testRequest = KituraRequest.request(.POST,
                                           "https://google.com",
-                                          parameters: [["asd":"asd"]],
+                                          parameters: ["asd":"asd"],
                                           headers: ["User-Agent":"Kitura-Server"]
   )
 
@@ -49,14 +49,14 @@ class RequestTests: XCTestCase {
             "http://httpbin.org/image/png").response { _, _, data, error in
                 guard let data = data else {
                     XCTFail("data should exits")
-                    return;
+                    return
                 }
 
                 KituraRequest.request(.POST,
                     "http://httpbin.org/post",
-                    parameters: [[
+                    parameters: [
                         "key" : "value"
-                    ]], encoding: MultipartEncoding([
+                    ], encoding: MultipartEncoding([
                         BodyPart(key: "file", data: data, mimeType: .image(.png), fileName: "image.jpg")
                     ])).response { _, _, data, error in
                         guard let string = dataToString(data) else {
@@ -64,13 +64,9 @@ class RequestTests: XCTestCase {
                             return
                         }
 
-                        if !string.contains("\"file\": \"data:image/png;base64,") {
-                            XCTFail("file should exits in request")
-                        }
+                        XCTAssertTrue(string.contains("\"file\": \"data:image/png;base64,"), "file should exits in request")
 
-                        if !string.contains("\"key\": \"value\"") {
-                            XCTFail("file should exits in request")
-                        }
+                        XCTAssertTrue(string.contains("\"key\": \"value\""), "key value should exits in request")
                 }
             }
     }

--- a/Tests/KituraRequestTests/RequestTests.swift
+++ b/Tests/KituraRequestTests/RequestTests.swift
@@ -65,7 +65,6 @@ class RequestTests: XCTestCase {
                         }
 
                         XCTAssertTrue(string.contains("\"file\": \"data:image/png;base64,"), "file should exits in request")
-
                         XCTAssertTrue(string.contains("\"key\": \"value\""), "key value should exits in request")
                 }
             }

--- a/Tests/KituraRequestTests/TestHelpers.swift
+++ b/Tests/KituraRequestTests/TestHelpers.swift
@@ -17,6 +17,6 @@
 import Foundation
 import KituraNet
 
-func dataToString(_ data: Data?) -> NSString? {
-  return data != nil ? NSString(data: data!, encoding: String.Encoding.utf8.rawValue) : nil
+func dataToString(_ data: Data?) -> String? {
+  return data != nil ? String(data: data!, encoding: .utf8) : nil
 }


### PR DESCRIPTION
Replaced `[[String : Any]]` for parameter type with `[String : Any]` 
Fixed tests in which unordered dictionary keys was causing failures.  
Updated Readme file for new encoding and parameter type.
