### PR TITLE
Update package API 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,17 +33,33 @@ API of KituraRequest should feel familiar as it closely maps the one of [Alamofi
 To create a request object simply call
 
 ```swift
-KituraRequest.request(.GET, "https://httpbin.org/get"]
+KituraRequest.request(.get, "https://httpbin.org/get"]
 ```
 
 #### Request parameters and parameters encoding
 You can also create a request with parameters by passing `[String: Any]` dictionary together with an encoding method:
 
 ```swift
-KituraRequest.request(.POST,
+KituraRequest.request(.post,
                       "https://httpbin.org/post",
                       parameters: ["foo":"bar"],
                       encoding: JSONEncoding.default)
+```
+
+```swift
+KituraRequest.request(.post,
+                      "https://httpbin.org/post",
+                      parameters: ["foo":"bar"],
+                      encoding: URLEncoding.default)
+```
+
+```swift
+KituraRequest.request(.post,
+                      "https://httpbin.org/post",
+                      parameters: ["foo":"bar"],
+                      encoding: MultipartEncoding([
+                        BodyPart(key: "file", data: data, mimeType: .image(.png), fileName: "image.jpg")
+                    ]))
 ```
 
 Currently `URLEncoding`, `JSONEncoding` and `MultipartEncoding` encodings is supported by default.
@@ -59,7 +75,7 @@ To create custom parameter encoding extend any class or struct with `Encoding` p
 To set headers in the request pass them as `[String: String]` dictionary as shown below:
 
 ```swift
-KituraRequest.request(.GET,
+KituraRequest.request(.get,
                       "https://httpbin.org/get",
                       headers: ["User-Agent":"Awesome-App"])
 ```
@@ -68,7 +84,7 @@ KituraRequest.request(.GET,
 Currently there is only one method that you can call to get back the requests response and it returns `NSData`.
 
 ```swift
-KituraRequest.request(.GET, "https://google.com"].response {
+KituraRequest.request(.get, "https://google.com").response {
   request, response, data, error in
   // do something with data
 }

--- a/Sources/KituraRequest/Encoding/MultipartEncoding.swift
+++ b/Sources/KituraRequest/Encoding/MultipartEncoding.swift
@@ -20,7 +20,7 @@ import Foundation
 public struct MultipartEncoding: Encoding {
 
     private var bodyParts: [BodyPart]?
-    init(_ bodyParts: [BodyPart]?) {
+    public init(_ bodyParts: [BodyPart]?) {
         self.bodyParts = bodyParts
     }
 

--- a/Sources/KituraRequest/Request.swift
+++ b/Sources/KituraRequest/Request.swift
@@ -31,7 +31,15 @@ public class Request {
     public typealias Parameters = [String : Any]
 
     public enum Method: String {
-        case CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE
+        case options = "OPTIONS"
+        case get     = "GET"
+        case head    = "HEAD"
+        case post    = "POST"
+        case put     = "PUT"
+        case patch   = "PATCH"
+        case delete  = "DELETE"
+        case trace   = "TRACE"
+        case connect = "CONNECT"
     }
 
     public typealias CompletionHandler = (_ request: ClientRequest?, _ response: ClientResponse?, _ data: Data?, _ error: Swift.Error?) -> Void

--- a/Tests/KituraRequestTests/E2ETests.swift
+++ b/Tests/KituraRequestTests/E2ETests.swift
@@ -21,7 +21,7 @@ import KituraRequest
 class E2ETests: XCTestCase {
 
   func testRequestReturnsData() {
-    KituraRequest.request(.GET, "https://httpbin.org/html")
+    KituraRequest.request(.get, "https://httpbin.org/html")
       .response {
         _, _, data, _ in
         if data != nil {

--- a/Tests/KituraRequestTests/RequestTests.swift
+++ b/Tests/KituraRequestTests/RequestTests.swift
@@ -22,7 +22,7 @@ import KituraNet
 
 class RequestTests: XCTestCase {
 
-  var testRequest = KituraRequest.request(.POST,
+  var testRequest = KituraRequest.request(.post,
                                           "https://google.com",
                                           parameters: ["asd":"asd"],
                                           headers: ["User-Agent":"Kitura-Server"]
@@ -45,14 +45,14 @@ class RequestTests: XCTestCase {
   }
 
     func testMultipartRequest() {
-        KituraRequest.request(.GET,
+        KituraRequest.request(.get,
             "http://httpbin.org/image/png").response { _, _, data, error in
                 guard let data = data else {
                     XCTFail("data should exits")
                     return
                 }
 
-                KituraRequest.request(.POST,
+                KituraRequest.request(.post,
                     "http://httpbin.org/post",
                     parameters: [
                         "key" : "value"

--- a/Tests/KituraRequestTests/URLFormatterTests.swift
+++ b/Tests/KituraRequestTests/URLFormatterTests.swift
@@ -28,31 +28,31 @@ class URLFormatterTests: XCTestCase {
 
   func testRequestWithInvalidReturnsError() {
     let invalidURL = "http://💩.com"
-    let testRequest = Request(method: .GET, invalidURL)
+    let testRequest = Request(method: .get, invalidURL)
     XCTAssertEqual(testRequest.error as? RequestError, RequestError.invalidURL)
   }
 
   func testRequestWithURLWithoutSchemeReturnsError() {
     let URLWithoutScheme = "apple.com"
-    let testRequest = Request(method: .GET, URLWithoutScheme)
+    let testRequest = Request(method: .get, URLWithoutScheme)
     XCTAssertEqual(testRequest.error as? RequestError, RequestError.noSchemeProvided)
   }
 
   func testRequestWithNoHostReturnsError() {
     let URLWithoutHost = "http://"
-    let testRequest = Request(method: .GET, URLWithoutHost)
+    let testRequest = Request(method: .get, URLWithoutHost)
     XCTAssertEqual(testRequest.error as? RequestError, RequestError.noHostProvided)
   }
 
   func testRequestWithNoHostAndQueryReturnsError() {
     let URLWithoutHost = "http://?asd=asd"
-    let testRequest = Request(method: .GET, URLWithoutHost)
+    let testRequest = Request(method: .get, URLWithoutHost)
     XCTAssertEqual(testRequest.error as? RequestError, RequestError.noHostProvided)
   }
 
   func testValidURLCreatesValidClientRequest() {
     let validURL = "https://66o.tech"
-    let testRequest = Request(method: .GET, validURL)
+    let testRequest = Request(method: .get, validURL)
 
     XCTAssertEqual(testRequest.request?.url, validURL)
   }


### PR DESCRIPTION
Made `MultipartEncoding` initializer public
Request.Method enum now conforms to Swift 3 API Design Guidelines
Fixed tests.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
