### PR TITLE
Added back the ignore = all for the gitmodule file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Package-Builder"]
 	path = Package-Builder
 	url = https://github.com/IBM-Swift/Package-Builder.git
-	branch = master
+	ignore = all


### PR DESCRIPTION
fixes issue https://github.com/IBM-Swift/Kitura/issues/829.  There is no need to have the branch = master in the file anymore since the travis file ensures master is always gotten
