### PR TITLE
Forget request after invoking response handler to stop leaking memory

### DIFF
--- a/Sources/KituraRequest/Request/Request.swift
+++ b/Sources/KituraRequest/Request/Request.swift
@@ -91,6 +91,7 @@ public class Request {
     public func response(_ completionHandler: @escaping CompletionHandler) {
         guard let response = response else {
             completionHandler(request, nil, nil, error)
+            request = nil
             return
         }
 
@@ -98,6 +99,7 @@ public class Request {
         do {
             _ = try response.read(into: &data)
             completionHandler(request, response, data, error)
+            request = nil
         } catch {
             Log.error("Error in Kirutra-Request response: \(error)")
         }


### PR DESCRIPTION
``KituraRequest.Request`` class uses ``KituraNet.ClientRequest`` class which in turn uses ``curl_easy_init`` from ``Ccurl``.

``KituraNet.ClientRequest`` will correctly cleanup after itself and will call ``curl_easy_cleanup`` when all references to it are lost.

``KituraRequest.Request`` however never seems to ``deinit`` itself and therefore keeps the ``ClientRequest`` around leaking a lot of memory over time, see #19 for example.

I'm not sure if this is a proper fix but it works