### PR TITLE
Fix bug that caused custom headers to be ignored.

### DIFF
--- a/Sources/KituraRequest/Request/Request.swift
+++ b/Sources/KituraRequest/Request/Request.swift
@@ -63,12 +63,13 @@ public class Request {
 
             options.append(.hostname(urlRequest.url!.absoluteString))
 
-            // headers
-            if let headers = headers {
+            // headers (defaults)
+            if let headers = urlRequest.allHTTPHeaderFields {
                 options.append(.headers(headers))
             }
-
-            if let headers = urlRequest.allHTTPHeaderFields {
+            
+            // headers (custom)
+            if let headers = headers {
                 options.append(.headers(headers))
             }
 


### PR DESCRIPTION
We should first append the headers created by the encoding.encode() call, as they contain defaults for content-type that the user might want to override with custom values. The custom headers should be appended last, so they can replace the default values set for the keys that have default values.
The current implementation causes custom header values to be ignored, as they are always replaced by defaults. This is neither expected nor desirable.