### PR TITLE
Include DELETE method

### DIFF
--- a/Sources/KituraRequest/Encoding/URLEncoding.swift
+++ b/Sources/KituraRequest/Encoding/URLEncoding.swift
@@ -91,7 +91,7 @@ public struct URLEncoding: Encoding {
             return true
         case (.httpBody, _):
             return false
-        case (_, "GET"), (_, "HEAD"):
+        case (_, "GET"), (_, "HEAD"), (_, "DELETE"):
             return true
         default:
             return false


### PR DESCRIPTION
Included DELETE method in shouldEncodeInQuery so the parameters are correctly encoded in the query when sending an HTTP DELETE API Call.