### PR TITLE
Swift 4 support, up Kitura-net dependency to 2.0.x

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "KituraRequest",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(name: "KituraRequest", targets: ["KituraRequest"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .upToNextMinor(from: "2.0.0")),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target defines a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(name: "KituraRequest", dependencies: ["KituraNet"]),
+        .testTarget(name: "KituraRequestTests", dependencies: ["KituraRequest"]),
+    ]
+)


### PR DESCRIPTION
This allows dependent libraries (eg object storage sdk and push notifications sdk) to support Kitura 2.1 (which requires Swift 4 and Kitura-net 2).

The package still compiles on Swift 3.1.1 but with Kitura-net 1.

NOTE: This update will allow the AppID SDK to work with Kitura 2.1.x in the short term. Since Kitura-Request is deprecated, the medium/long term goal will be to update AppID SDK to use SwiftyRequest instead.